### PR TITLE
Merge upstream updates to liballoc

### DIFF
--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -139,7 +139,7 @@ jobs:
             **DO NOT MERGE THIS PULL REQUEST!**  Instead, in your local repo:
 
             ```text
-            git pull --no-ff -Xsubtree=src/liballoc '${{ github.server_url }}/${{ github.repository }}.git' refs/pull/id/head
+            git pull -Xsubtree=src/liballoc ${{ github.repositoryUrl }} refs/pull/id/head
             ```
             where `id` is the number of this pull request.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ extend_one = []
 hasher_prefixfree_extras = []
 inline_const = []
 inplace_iteration = []
+is_sorted = []
 maybe_uninit_slice = []
 new_uninit = []
 rustc_attrs = []
@@ -38,6 +39,7 @@ nightly = [
     "hasher_prefixfree_extras",
     "inline_const",
     "inplace_iteration",
+    "is_sorted",
     "maybe_uninit_slice",
     "new_uninit",
     "rustc_attrs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@
 #![cfg_attr(feature = "hasher_prefixfree_extras", feature(hasher_prefixfree_extras))]
 #![cfg_attr(feature = "inline_const", feature(inline_const))]
 #![cfg_attr(feature = "inplace_iteration", feature(inplace_iteration))]
+#![cfg_attr(feature = "is_sorted", feature(is_sorted))]
 #![cfg_attr(feature = "maybe_uninit_slice", feature(maybe_uninit_slice))]
 #![cfg_attr(feature = "new_uninit", feature(new_uninit))]
 #![cfg_attr(feature = "rustc_attrs", feature(rustc_attrs))]

--- a/src/liballoc/collections/binary_heap/tests.rs
+++ b/src/liballoc/collections/binary_heap/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::liballoc::testing::crash_test::{CrashTestDummy, Panic};
+use crate::polyfill::*;
 use alloc::boxed::Box;
+use core::mem;
 #[cfg(feature = "trusted_len")]
 use std::iter::TrustedLen;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -152,6 +154,24 @@ fn test_peek_mut() {
         *top -= 2;
     }
     assert_eq!(heap.peek(), Some(&9));
+}
+
+#[test]
+fn test_peek_mut_leek() {
+    let data = vec![4, 2, 7];
+    let mut heap = BinaryHeap::from(data);
+    let mut max = heap.peek_mut().unwrap();
+    *max = -1;
+
+    // The PeekMut object's Drop impl would have been responsible for moving the
+    // -1 out of the max position of the BinaryHeap, but we don't run it.
+    mem::forget(max);
+
+    // Absent some mitigation like leak amplification, the -1 would incorrectly
+    // end up in the last position of the returned Vec, with the rest of the
+    // heap's original contents in front of it in sorted order.
+    let sorted_vec = heap.into_sorted_vec();
+    assert!(sorted_vec.is_sorted(), "{:?}", sorted_vec);
 }
 
 #[test]


### PR DESCRIPTION
From #11:

- Add test of leaking a binary_heap PeekMut
- Leak amplification for peek_mut() to ensure BinaryHeap's invariant is always met
- Document guarantees about BinaryHeap invariant
